### PR TITLE
parse font name correctly

### DIFF
--- a/src/bdf.js
+++ b/src/bdf.js
@@ -101,7 +101,7 @@
           meta.version = data[1];
           break;
         case "FONT":
-          meta.name = data[1];
+          meta.name = line.substr(data[0].length).trim();
           break;
         case "SIZE":
           meta.size = {


### PR DESCRIPTION
font names can have spaces

reference: https://wiki.archlinux.org/index.php/X_Logical_Font_Description